### PR TITLE
Prevent a zombie apocalypse

### DIFF
--- a/etc/systemd/system/mesos-slave.service
+++ b/etc/systemd/system/mesos-slave.service
@@ -13,6 +13,7 @@ ExecStartPre=/usr/bin/docker pull mesosphere/mesos-slave:0.20.1
 ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
     --name=mesos_slave \
     --net=host \
+    --pid=host \
     --privileged \
     -v /sys:/sys \
     -v /usr/bin/docker:/usr/bin/docker:ro \


### PR DESCRIPTION
Let Mesos slave container use the PID namespace of the host (`--pid=host`). Subsequently, this prevents the otherwise inevitable zombie apocalypse described in issue https://github.com/mesosphere/docker-containers/issues/9.
